### PR TITLE
Fix signal handling inside docker container

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -4,4 +4,4 @@ RUN apk add --update ca-certificates
 
 ADD ./tmp/go-eventsource /go-eventsource
 
-CMD /go-eventsource
+CMD ["/go-eventsource"]

--- a/eventsource.go
+++ b/eventsource.go
@@ -143,7 +143,12 @@ func setupSignalHandlers(consumer consumer.Consumer) {
 		}
 		Info("Shutting down gracefully. Repeat signal to force shutdown")
 		shuttingDown = true
-		consumer.Remove()
+		Info("Removing consumer")
+		err := consumer.Remove()
+		if err != nil {
+			Fatal("Could not remove subscription %s: %v", *subscriptionName, err)
+		}
+		Info("Consumer removed successfully. Exiting")
 		os.Exit(0)
 	}()
 }


### PR DESCRIPTION
The container was not handling signals correctly because it was running
inside a shell, so the shell received the signals instead of the actual
Go process. This is because of the syntax of docker's CMD [1]

Also added better error handling when removing subscription

[1]: http://stackoverflow.com/questions/33379567/sending-signals-to-golang-application-in-docker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/replaygaming/go-eventsource/10)
<!-- Reviewable:end -->
